### PR TITLE
Remove this repo from upstream.repos

### DIFF
--- a/upstream.repos
+++ b/upstream.repos
@@ -1,9 +1,5 @@
 # Upstream dependencies
 repositories:
-  UR10e_welding_demo:
-    type: git
-    url: https://github.com/PickNikRobotics/UR10e_welding_demo.git
-    version: master
   Universal_Robots_Client_Library:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Before this:

1. `git checkout some-branch`
2. `cd .. ; vcs import < UR10e_welding_demo/upstream.repos`
3. Now UR10e_welding_demo is back on the main branch  